### PR TITLE
Update resources for new AzureAD Provider

### DIFF
--- a/simple-server-aks/terraform/modules/service-principal/outputs.tf
+++ b/simple-server-aks/terraform/modules/service-principal/outputs.tf
@@ -1,14 +1,12 @@
-
 output "service_principal_id" {
-  value = "${azurerm_azuread_service_principal.service-principal.id}"
+  value = "${azuread_service_principal.service-principal.id}"
 }
 
 output "service_principal_client_id" {
-  value = "${azurerm_azuread_service_principal.service-principal.application_id}"
+  value = "${azuread_service_principal.service-principal.application_id}"
 }
 
 output "service_principal_client_secret" {
   sensitive = true
   value     = "${random_string.service-principal-random-password.result}"
 }
-

--- a/simple-server-aks/terraform/modules/service-principal/service-principal.tf
+++ b/simple-server-aks/terraform/modules/service-principal/service-principal.tf
@@ -3,12 +3,12 @@ locals {
   my_env   = "${var.prefix}-${var.env}"
 }
 
-resource "azurerm_azuread_application" "service-principal-app" {
-    name = "${var.prefix}-${var.env}-${var.name}-app"
+resource "azuread_application" "service-principal-app" {
+    name = "${var.prefix}-${var.environment}-aks-app"
 }
 
-resource "azurerm_azuread_service_principal" "service-principal" {
-    application_id = "${azurerm_azuread_application.service-principal-app.application_id}"
+resource "azuread_service_principal" "service-principal" {
+    application_id = "${azuread_application.service-principal-app.application_id}"
 }
 
 resource "random_string" "service-principal-random-password" {
@@ -16,12 +16,12 @@ resource "random_string" "service-principal-random-password" {
   special = true
 
   keepers = {
-    service_principal = "${azurerm_azuread_service_principal.service-principal.id}"
+    service_principal = "${azuread_service_principal.service-principal.id}"
   }
 }
 
-resource "azurerm_azuread_service_principal_password" "service-principal-password" {
-    service_principal_id = "${azurerm_azuread_service_principal.service-principal.id}"
+resource "azuread_service_principal_password" "service-principal-password" {
+    service_principal_id = "${azuread_service_principal.service-principal.id}"
     value                = "${random_string.service-principal-random-password.result}"
     # 720h = 1 month, should be enough for this exercise.
     end_date             = "${timeadd(timestamp(), "720h")}"


### PR DESCRIPTION
Hello! Hopefully you don't mind me raising a PR on this repo. I've been using this code recently and found it really helpful. I really appreciated the insights into the pain of managing service principals with Terraform as it was exactly the problem I experienced.

There is a new provider for AzureAD which makes it a lot less wordy and potentially easier to use. If you run newer versions of Terraform it will warn you that the old resources will be deprecated soon. Here is the output on my machine:

```
> terraform version
Terraform v0.11.13
+ provider.azuread v0.1.0
+ provider.azurerm v1.24.0
+ provider.random v2.1.1
```

And the deprecation warnings you'll get when using resources like `azurerm_azuread_service_principal`:
```
Warning: module.dev.module.service_principal.azurerm_azuread_service_principal.service-principal: The Azure Active Directory resources have been split out into their own Provider.

Information on migrating to the new AzureAD Provider can be found here: https://terraform.io/docs/providers/azurerm/guides/migrating-to-azuread.html

As such the Azure Active Directory resources within the AzureRM Provider are now deprecated and will be removed in v2.0 of the AzureRM Provider.
```

If you add the new AzureAD provider the deprecation warnings will disappear.

The code you've provided will work absolutely fine for the time being. I'm not sure when the changes will go into effect but I have tested moving to the new provider and it works just fine.